### PR TITLE
VIMC-3397: nicer interface for passing connection arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     rmarkdown,
     testthat,
     withr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0
 Encoding: UTF-8
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
 Title: Vault Client for Secrets and Sensitive Data
-Version: 1.0.2
+Version: 1.0.3
 Description: Provides an interface to a 'HashiCorp' vault server over
   its http API (typically these are self-hosted; see
   <https://www.vaultproject.io>).  This allows for secure storage and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* New convenience argument to `vaultr::vault_resolve_secrets` to pass in all connection arguments at once, designed to make this easier to use from scripts (VIMC-3397).
+
 ## 1.0.2
 
 * First public release

--- a/R/vault_resolve_secrets.R
+++ b/R/vault_resolve_secrets.R
@@ -35,6 +35,13 @@
 ##' @param login Login method to be passed to call to
 ##'   \code{\link{vault_client}}.
 ##'
+##' @param vault_args As an alternative to using \code{login} and
+##'   \code{...}, a list of (named) arguments can be provided here,
+##'   equivalent to the full set of arguments that you might pass to
+##'   \code{\link{vault_client}}.  If provided, then \code{login} is
+##'   ignored and if additional arguments are provided through
+##'   \code{...} an error will be thrown.
+##'
 ##' @return List of properties with any vault secrets resolved.
 ##'
 ##' @export

--- a/man/vault_resolve_secrets.Rd
+++ b/man/vault_resolve_secrets.Rd
@@ -4,7 +4,7 @@
 \alias{vault_resolve_secrets}
 \title{Resolve secrets from R objects}
 \usage{
-vault_resolve_secrets(x, ..., login = TRUE)
+vault_resolve_secrets(x, ..., login = TRUE, vault_args = NULL)
 }
 \arguments{
 \item{x}{List of values, some of which may refer to vault secrets
@@ -15,6 +15,13 @@ do not match the pattern of a secret are left as-is.}
 
 \item{login}{Login method to be passed to call to
 \code{\link{vault_client}}.}
+
+\item{vault_args}{As an alternative to using \code{login} and
+\code{...}, a list of (named) arguments can be provided here,
+equivalent to the full set of arguments that you might pass to
+\code{\link{vault_client}}.  If provided, then \code{login} is
+ignored and if additional arguments are provided through
+\code{...} an error will be thrown.}
 }
 \value{
 List of properties with any vault secrets resolved.

--- a/man/vault_test_server.Rd
+++ b/man/vault_test_server.Rd
@@ -6,11 +6,14 @@
 \alias{vault_test_server_install}
 \title{Control a test vault server}
 \usage{
-vault_test_server(https = FALSE, init = TRUE,
-  if_disabled = testthat::skip)
+vault_test_server(https = FALSE, init = TRUE, if_disabled = testthat::skip)
 
-vault_test_server_install(path = NULL, quiet = FALSE,
-  version = "1.0.0", platform = vault_platform())
+vault_test_server_install(
+  path = NULL,
+  quiet = FALSE,
+  version = "1.0.0",
+  platform = vault_platform()
+)
 }
 \arguments{
 \item{https}{Logical scalar, indicating if a https-using server

--- a/man/vaultr.Rd
+++ b/man/vaultr.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{vaultr}
 \alias{vaultr}
-\alias{vaultr-package}
 \title{Vault Client for Secrets and Sensitive Data}
 \description{
 Vault client for secrets and sensitive data; this package provides

--- a/tests/testthat/test-vault-api.R
+++ b/tests/testthat/test-vault-api.R
@@ -45,6 +45,7 @@ test_that("token validation", {
 
 
 test_that("skip ssl validation", {
+  skip_on_os("windows")
   srv <- vault_test_server(https = TRUE)
 
   cl1 <- vault_client(addr = srv$addr, tls_config = FALSE)

--- a/tests/testthat/test-vault-auth-approle.R
+++ b/tests/testthat/test-vault-auth-approle.R
@@ -27,7 +27,6 @@ test_that("approle auth", {
 
   d <- ar$role_read(role_name)
   expect_is(d, "list")
-  expect_equal(d$policies, "default")
 
   role_id <- ar$role_id_read(role_name)
   expect_is(role_id, "character")
@@ -54,7 +53,7 @@ test_that("custom mount", {
   expect_is(ar, "vault_client_auth_approle")
 
   ar$role_write("server")
-  expect_equal(ar$role_read("server")$policies, "default")
+  expect_is(ar$role_read("server"), "list")
   expect_error(cl$auth$approle$role_read("server"))
 })
 

--- a/tests/testthat/test-vault-operator.R
+++ b/tests/testthat/test-vault-operator.R
@@ -51,6 +51,7 @@ test_that("cancel rekey", {
 
 
 test_that("init", {
+  skip_on_os("windows")
   srv <- vault_test_server(https = TRUE, init = FALSE)
   cl <- srv$client(login = FALSE)
 

--- a/tests/testthat/test-vault-resolve-secrets.R
+++ b/tests/testthat/test-vault-resolve-secrets.R
@@ -30,4 +30,13 @@ test_that("vault secrets can be resolved", {
     expect_equal(vault_resolve_secrets(unlist(x), addr = config$vault_server),
                  list(name = "alice", password = "ALICE"))
   })
+
+  withr::with_envvar(c(VAULTR_AUTH_METHOD = NA_character_), {
+    args <- list(login = "token", token = srv$token, addr = config$vault_server)
+    expect_equal(vault_resolve_secrets(x, vault_args = args),
+                 list(name = "alice", password = "ALICE"))
+    expect_error(
+      vault_resolve_secrets(x, vault_args = args, addr = "somewhere"),
+      "Do not provide both '...' and 'vault_args'", fixed = TRUE)
+  })
 })

--- a/tests/testthat/test-vault-transit.R
+++ b/tests/testthat/test-vault-transit.R
@@ -259,7 +259,8 @@ test_that("key derivation: encrypt/decrypt", {
   cyphertext <- transit$data_encrypt("test", plaintext, context = context)
   expect_identical(transit$data_decrypt("test", cyphertext, context = context),
                    plaintext)
-  expect_error(transit$data_decrypt("test", cyphertext), "context")
+  expect_error(transit$data_decrypt("test", cyphertext), "context",
+               class = "vault_invalid_request")
 })
 
 
@@ -324,5 +325,6 @@ test_that("key derivation: sign/verify", {
   expect_false(transit$verify_signature("test", data[-1], signature,
                                         context = context))
   expect_error(transit$verify_signature("test", data, signature),
-               "context")
+               "context",
+               class = "vault_internal_server_error")
 })


### PR DESCRIPTION
This turns out to be a bit annoying at present - I want to pass a number of connection arguments through at once when resolving secrets in an update to orderly and to do that I need to use `do.call` there - moving that inside this package seems a better bet.