### PR TITLE
VIMC-3437: Better error messages when secrets can't be resolved

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
 Title: Vault Client for Secrets and Sensitive Data
-Version: 1.0.3
+Version: 1.0.4
 Description: Provides an interface to a 'HashiCorp' vault server over
   its http API (typically these are self-hosted; see
   <https://www.vaultproject.io>).  This allows for secure storage and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* `vaultr::vault_resolve_secrets` (and `$read` in the kv1 secrets engine) provide more information about what was being read at the point of failure (VIMC-3437)
+
 ## 1.0.3
 
 * New convenience argument to `vaultr::vault_resolve_secrets` to pass in all connection arguments at once, designed to make this easier to use from scripts (VIMC-3397).

--- a/R/vault_client_kv1.R
+++ b/R/vault_client_kv1.R
@@ -88,8 +88,10 @@ vault_kv_read <- function(api_client, mount, path, field = NULL,
   res <- tryCatch(
     api_client$GET(path),
     vault_invalid_path = function(e) NULL,
-    error = function(e)
-      stop(sprintf("While reading %s:\n %s", path, e$message), call. = FALSE))
+    error = function(e) {
+      e$message <- sprintf("While reading %s:\n %s", path, e$message)
+      stop(e)
+    })
 
   if (is.null(res)) {
     ret <- NULL

--- a/R/vault_client_kv1.R
+++ b/R/vault_client_kv1.R
@@ -87,7 +87,9 @@ vault_kv_read <- function(api_client, mount, path, field = NULL,
   path <- vault_validate_path(path, mount)
   res <- tryCatch(
     api_client$GET(path),
-    vault_invalid_path = function(e) NULL)
+    vault_invalid_path = function(e) NULL,
+    error = function(e)
+      stop(sprintf("While reading %s:\n %s", path, e$message), call. = FALSE))
 
   if (is.null(res)) {
     ret <- NULL

--- a/tests/testthat/test-vault-resolve-secrets.R
+++ b/tests/testthat/test-vault-resolve-secrets.R
@@ -61,5 +61,6 @@ test_that("Provide better error messages when failing to read", {
   args <- list(login = "token", token = token, addr = srv$addr)
   expect_error(
     vault_resolve_secrets(x, vault_args = args),
-    "While reading secret/users/bob:")
+    "While reading secret/users/bob:",
+    class = "vault_forbidden")
 })


### PR DESCRIPTION
As currently implemented, if secrets can't be resolved then the user sees

```
Error: 1 error occurred:
	* permission denied
```

and a stack trace of

```
25: stop(vault_error(code, text, errors))
24: vault_client_response(res, to_json)
23: vault_request(verb, self$base_url, self$tls_config, token, path,
        ...)
22: self$request(httr::GET, path, ...)
21: api_client$GET(path)
20: doTryCatch(return(expr), name, parentenv, handler)
19: tryCatchOne(expr, names, parentenv, handlers[[1L]])
18: tryCatchList(expr, classes, parentenv, handlers)
17: tryCatch(api_client$GET(path), vault_invalid_path = function(e) NULL)
16: vault_kv_read(private$api_client, private$mount, path, field,
        metadata)
15: self$secrets$kv1$read(path, field, metadata)
14: (function (path, field = NULL, metadata = FALSE)
    {
        self$secrets$kv1$read(path, field, metadata)
    })(dots[[1L]][[1L]], dots[[2L]][[1L]])
13: mapply(FUN = f, ..., SIMPLIFY = FALSE)
12: Map(vault$read, key, field)
11: unname(Map(vault$read, key, field))
10: vault_resolve_secrets(vcapply(x[i], identity), ..., login = login)
9: vaultr::vault_resolve_secrets(x$args, addr = config$vault_server)
8: force(code)
7: withr::with_envvar(envir_read(config$path), resolved_args <- vaultr::vault_resolve_secrets(x$args,
       addr = config$vault_server))
6: dettl_db_args(path, type)
5: db_connect(db_name, self$path)
4: self$reload()
3: .subset2(public_bind_env, "initialize")(...)
2: DataImport$new(path, db_name)
1: dettl::dettl(path = ".", db_name = "science")
```

which does not really enlighten as to what the problem was.

**However** a more general fix might be preferable. If the custom error class was to take `path` (and realistically an action) as an argument we could provide similar errors on all endpoints (that would have to go into `vault_error`, via `vault_client_response` via `vault_request` and through the api client).  There might not always be a nice mapping for non-kv things here, such as writing to the policies