### PR TITLE
Add support for vault namespaces

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -32,7 +32,8 @@ jobs:
         run: echo "VAULTR_TEST_SERVER_BIN_PATH=$GITHUB_WORKSPACE/.vault" >> $GITHUB_ENV
 
       - name: Test coverage
-        env: VAULTR_TEST_GITHUB_PAT: ${{ secrets.VAULTR_TEST_GITHUB_PAT }}
+        env:
+          VAULTR_TEST_GITHUB_PAT: ${{ secrets.VAULTR_TEST_GITHUB_PAT }}
         run: |
           covr::codecov(
             quiet = FALSE,

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -32,8 +32,9 @@ jobs:
         run: echo "VAULTR_TEST_SERVER_BIN_PATH=$GITHUB_WORKSPACE/.vault" >> $GITHUB_ENV
 
       - name: Test coverage
-        env:
-          VAULTR_TEST_GITHUB_PAT: ${{ secrets.VAULTR_TEST_GITHUB_PAT }}
+        # We should re-enable an environment variable here
+        # VAULTR_TEST_GITHUB_PAT to run the last test, but that would
+        # be better as an interaction test really.
         run: |
           covr::codecov(
             quiet = FALSE,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
 Title: Vault Client for Secrets and Sensitive Data
-Version: 1.1.1
+Version: 1.1.2
 Description: Provides an interface to a 'HashiCorp' vault server over
   its http API (typically these are self-hosted; see
   <https://www.vaultproject.io>).  This allows for secure storage and
@@ -30,7 +30,7 @@ Suggests:
     rmarkdown,
     testthat,
     withr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 VignetteBuilder: knitr
 Language: en-GB

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Support for vault [namespaces](https://developer.hashicorp.com/vault/tutorials/enterprise/namespaces) on enterprise versions of vault
+
 ## 1.0.4
 
 * `vaultr::vault_resolve_secrets` (and `$read` in the kv1 secrets engine) provide more information about what was being read at the point of failure (VIMC-3437)

--- a/R/http.R
+++ b/R/http.R
@@ -1,4 +1,4 @@
-vault_request <- function(verb, url, verify, token, path, ...,
+vault_request <- function(verb, url, verify, token, namespace, path, ...,
                           body = NULL, wrap_ttl = NULL,
                           to_json = TRUE,
                           allow_missing_token = FALSE) {
@@ -7,11 +7,14 @@ vault_request <- function(verb, url, verify, token, path, ...,
   } else if (!allow_missing_token) {
     stop("Have not authenticated against vault", call. = FALSE)
   }
+  if (!is.null(namespace)) {
+    namespace <- httr::add_headers("X-Vault-Namespace" = namespace)
+  }
   if (!is.null(wrap_ttl)) {
     assert_is_duration(wrap_ttl)
     wrap_ttl <- httr::add_headers("X-Vault-Wrap-TTL" = wrap_ttl)
   }
-  res <- verb(paste0(url, prepare_path(path)), verify, token,
+  res <- verb(paste0(url, prepare_path(path)), verify, token, namespace,
               httr::accept_json(), wrap_ttl,
               body = body, encode = "json", ...)
   vault_client_response(res, to_json)

--- a/R/vault_client.R
+++ b/R/vault_client.R
@@ -50,14 +50,12 @@
 ##'   to the environment variable `VAULT_CAPATH`, which is the
 ##'   same as vault's command line client.
 ##'
-##' @param namespace A [vault
-##'   namespace](https://developer.hashicorp.com/vault/tutorials/enterprise/namespaces),
-##'   when using enterprise vault. If given, then this must a string,
-##'   and your vault must support namespaces, which is an enterprise
-##'   feature. If the environment variable `VAULT_NAMESPACE` is set,
-##'   we use that namespace when `NULL` is provided as an argument
-##'   (this is the same variable as used by vault's command line
-##'   client).
+##' @param namespace A vault namespace, when using enterprise
+##'   vault. If given, then this must a string, and your vault must
+##'   support namespaces, which is an enterprise feature. If the
+##'   environment variable `VAULT_NAMESPACE` is set, we use that
+##'   namespace when `NULL` is provided as an argument (this is the
+##'   same variable as used by vault's command line client).
 ##'
 ##' @export
 ##' @author Rich FitzJohn

--- a/R/vault_client.R
+++ b/R/vault_client.R
@@ -50,6 +50,15 @@
 ##'   to the environment variable `VAULT_CAPATH`, which is the
 ##'   same as vault's command line client.
 ##'
+##' @param namespace A [vault
+##'   namespace](https://developer.hashicorp.com/vault/tutorials/enterprise/namespaces),
+##'   when using enterprise vault. If given, then this must a string,
+##'   and your vault must support namespaces, which is an enterprise
+##'   feature. If the environment variable `VAULT_NAMESPACE` is set,
+##'   we use that namespace when `NULL` is provided as an argument
+##'   (this is the same variable as used by vault's command line
+##'   client).
+##'
 ##' @export
 ##' @author Rich FitzJohn
 ##' @examples
@@ -101,8 +110,9 @@
 ##'
 ##'   client$delete("/secret/users/alice")
 ##' }
-vault_client <- function(login = FALSE, ..., addr = NULL, tls_config = NULL) {
-  client <- vault_client_$new(addr, tls_config)
+vault_client <- function(login = FALSE, ..., addr = NULL, tls_config = NULL,
+                         namespace = NULL) {
+  client <- vault_client_$new(addr, tls_config, namespace)
   method <- vault_client_login_method(login)
   if (!is.null(method)) {
     client$login(..., method = method)
@@ -152,9 +162,11 @@ vault_client_ <- R6::R6Class(
     ##' @param addr The vault address, including protocol and port
     ##'
     ##' @param tls_config The TLS config, if used
-    initialize = function(addr, tls_config) {
+    ##'
+    ##' @param namespace The namespace, if used
+    initialize = function(addr, tls_config, namespace) {
       super$initialize("core methods for interacting with vault")
-      api_client <- vault_api_client$new(addr, tls_config)
+      api_client <- vault_api_client$new(addr, tls_config, namespace)
 
       private$api_client <- api_client
 

--- a/R/vault_client.R
+++ b/R/vault_client.R
@@ -51,7 +51,7 @@
 ##'   same as vault's command line client.
 ##'
 ##' @param namespace A vault namespace, when using enterprise
-##'   vault. If given, then this must a string, and your vault must
+##'   vault. If given, then this must be a string, and your vault must
 ##'   support namespaces, which is an enterprise feature. If the
 ##'   environment variable `VAULT_NAMESPACE` is set, we use that
 ##'   namespace when `NULL` is provided as an argument (this is the

--- a/man/vault_api_client.Rd
+++ b/man/vault_api_client.Rd
@@ -54,6 +54,8 @@ api version path)}
 
 \item{\code{tls_config}}{Information used in TLS config, if used}
 
+\item{\code{namespace}}{The vault namespace, if used}
+
 \item{\code{token}}{The vault token, if authenticated}
 
 \item{\code{version}}{The vault server version, once queried}
@@ -90,7 +92,7 @@ api version path)}
 \subsection{Method \code{new()}}{
 Create a new api client
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{vault_api_client$new(addr = NULL, tls_config = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{vault_api_client$new(addr = NULL, tls_config = NULL, namespace = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -99,6 +101,8 @@ Create a new api client
 \item{\code{addr}}{Address of the vault server}
 
 \item{\code{tls_config}}{Optional TLS config}
+
+\item{\code{namespace}}{Optional namespace}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/vault_client.Rd
+++ b/man/vault_client.Rd
@@ -38,13 +38,12 @@ self-signed certificate you will need to provide this.  Defaults
 to the environment variable \code{VAULT_CAPATH}, which is the
 same as vault's command line client.}
 
-\item{namespace}{A \href{https://developer.hashicorp.com/vault/tutorials/enterprise/namespaces}{vault namespace},
-when using enterprise vault. If given, then this must a string,
-and your vault must support namespaces, which is an enterprise
-feature. If the environment variable \code{VAULT_NAMESPACE} is set,
-we use that namespace when \code{NULL} is provided as an argument
-(this is the same variable as used by vault's command line
-client).}
+\item{namespace}{A vault namespace, when using enterprise
+vault. If given, then this must a string, and your vault must
+support namespaces, which is an enterprise feature. If the
+environment variable \code{VAULT_NAMESPACE} is set, we use that
+namespace when \code{NULL} is provided as an argument (this is the
+same variable as used by vault's command line client).}
 }
 \description{
 Make a vault client.  This must be done before accessing the

--- a/man/vault_client.Rd
+++ b/man/vault_client.Rd
@@ -5,7 +5,13 @@
 \alias{vault_client_}
 \title{Make a vault client}
 \usage{
-vault_client(login = FALSE, ..., addr = NULL, tls_config = NULL)
+vault_client(
+  login = FALSE,
+  ...,
+  addr = NULL,
+  tls_config = NULL,
+  namespace = NULL
+)
 }
 \arguments{
 \item{login}{Login method.  Specify a string to be passed along as
@@ -31,6 +37,14 @@ can be left blank.  However, if your vault server uses a
 self-signed certificate you will need to provide this.  Defaults
 to the environment variable \code{VAULT_CAPATH}, which is the
 same as vault's command line client.}
+
+\item{namespace}{A \href{https://developer.hashicorp.com/vault/tutorials/enterprise/namespaces}{vault namespace},
+when using enterprise vault. If given, then this must a string,
+and your vault must support namespaces, which is an enterprise
+feature. If the environment variable \code{VAULT_NAMESPACE} is set,
+we use that namespace when \code{NULL} is provided as an argument
+(this is the same variable as used by vault's command line
+client).}
 }
 \description{
 Make a vault client.  This must be done before accessing the
@@ -166,7 +180,7 @@ Rich FitzJohn
 Create a new vault client. Not typically called
 directly, but via the \code{vault_client} method.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{vault_client_$new(addr, tls_config)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{vault_client_$new(addr, tls_config, namespace)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -175,6 +189,8 @@ directly, but via the \code{vault_client} method.
 \item{\code{addr}}{The vault address, including protocol and port}
 
 \item{\code{tls_config}}{The TLS config, if used}
+
+\item{\code{namespace}}{The namespace, if used}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/vault_client.Rd
+++ b/man/vault_client.Rd
@@ -39,7 +39,7 @@ to the environment variable \code{VAULT_CAPATH}, which is the
 same as vault's command line client.}
 
 \item{namespace}{A vault namespace, when using enterprise
-vault. If given, then this must a string, and your vault must
+vault. If given, then this must be a string, and your vault must
 support namespaces, which is an enterprise feature. If the
 environment variable \code{VAULT_NAMESPACE} is set, we use that
 namespace when \code{NULL} is provided as an argument (this is the

--- a/tests/testthat/helper-vault.R
+++ b/tests/testthat/helper-vault.R
@@ -69,6 +69,8 @@ fake_api_client <- function(addr, success) {
 
 
 wait_kv_upgrade <- function(kv, p, n = 50, poll = 0.2) { # max 10s by default
+  force(p)
+  force(kv)
   for (i in seq_len(n)) {
     ok <- tryCatch({
       kv$list(p)

--- a/tests/testthat/test-vault-kv2.R
+++ b/tests/testthat/test-vault-kv2.R
@@ -241,7 +241,7 @@ test_that("put+cas", {
 
   cl$secrets$enable("kv", "secret2", version = 2)
   kv <- cl$secrets$kv2$custom_mount("secret2")
-  wait_kv_upgrade(kv, p)
+  wait_kv_upgrade(kv, "secret2")
 
   d <- kv$put("secret2/a", list(a = 1))
   expect_error(kv$put("secret2/a", list(a = 2), cas = 2))

--- a/tests/testthat/test-vault-kv2.R
+++ b/tests/testthat/test-vault-kv2.R
@@ -224,7 +224,7 @@ test_that("mount validation", {
 
   cl$secrets$enable("kv", "secret2", version = 2)
   kv <- cl$secrets$kv2$custom_mount("secret2")
-  wait_kv_upgrade(kv, p)
+  wait_kv_upgrade(kv, "secret2")
 
   expect_error(
     kv$list("/secret"),

--- a/tests/testthat/test-vault.R
+++ b/tests/testthat/test-vault.R
@@ -8,6 +8,7 @@ test_that("api", {
 
   api <- cl$api()
   expect_is(api, "vault_api_client")
+  expect_null(api$namespace)
   ## Unauthenticated route:
   expect_equal(api$GET("/sys/seal-status"),
                cl$operator$seal_status())
@@ -15,4 +16,62 @@ test_that("api", {
   ## Authenticated route
   d <- api$GET("/secret/a")
   expect_equal(d$data$key, 1)
+})
+
+
+test_that("Can send namespace with api requests", {
+  skip_on_cran()
+  skip_if_not_installed("mockery")
+  cl <- vault_api_client$new("https://example.com", namespace = "foo")
+  cl$token <- "secret"
+  expect_equal(cl$namespace, "foo")
+  mock_response <- structure(
+    list(status_code = 204),
+    class = "response")
+  mock_get <- mockery::mock(mock_response)
+
+  expect_null(cl$request(mock_get, "/some/path"))
+  mockery::expect_called(mock_get, 1)
+  args <- mockery::mock_args(mock_get)[[1]]
+  expect_equal(args[[3]],
+               httr::add_headers("X-Vault-Token" = "secret"))
+  expect_equal(args[[4]],
+               httr::add_headers("X-Vault-Namespace" = "foo"))
+})
+
+
+test_that("No namespace sent by default", {
+  skip_on_cran()
+  skip_if_not_installed("mockery")
+  cl <- vault_api_client$new("https://example.com", namespace = NULL)
+  cl$token <- "secret"
+  expect_null(cl$namespace, NULL)
+  mock_response <- structure(
+    list(status_code = 204),
+    class = "response")
+  mock_get <- mockery::mock(mock_response)
+
+  expect_null(cl$request(mock_get, "/some/path"))
+  mockery::expect_called(mock_get, 1)
+  args <- mockery::mock_args(mock_get)[[1]]
+  expect_equal(args[[3]],
+               httr::add_headers("X-Vault-Token" = "secret"))
+  expect_null(args[[4]])
+})
+
+
+test_that("can set namespace when building client", {
+  skip_on_cran()
+  skip_if_not_installed("withr")
+  withr::with_envvar(
+    c(VAULT_NAMESPACE = "foo", VAULT_ADDR = "https://example.com"), {
+      expect_equal(vault_client()$api()$namespace, "foo")
+      expect_equal(vault_client(namespace = "bar")$api()$namespace, "bar")
+    })
+
+  withr::with_envvar(
+    c(VAULT_NAMESPACE = NA_character_, VAULT_ADDR = "https://example.com"), {
+      expect_null(vault_client()$api()$namespace)
+      expect_equal(vault_client(namespace = "bar")$api()$namespace, "bar")
+    })
 })


### PR DESCRIPTION
This PR adds support for vault namespaces; see #38 for context. It looks like all we need to do here is pass around a namespace header and everything should just work - so this PR takes the same approach as for the `tls_config` and moves it around into the api client, then we just test that the header is included in requests