### PR TITLE
Rebuild vignettes

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,10 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Move real vignettes
+        run: |
+          cp vignettes_src/* vignettes
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,9 +52,6 @@ jobs:
         run: |
           cp vignettes_src/* vignettes
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,6 +52,9 @@ jobs:
         run: |
           cp vignettes_src/* vignettes
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
 Title: Vault Client for Secrets and Sensitive Data
-Version: 1.1.5
+Version: 1.1.6
 Description: Provides an interface to a 'HashiCorp' vault server over
   its http API (typically these are self-hosted; see
   <https://www.vaultproject.io>).  This allows for secure storage and

--- a/vignettes_src/packages.Rmd
+++ b/vignettes_src/packages.Rmd
@@ -100,8 +100,11 @@ in a test will gracefully skip a test
 Sys.setenv("VAULTR_TEST_SERVER_BIN_PATH" = NA_character_)
 ```
 
-```{r, error = TRUE}
+<!-- can't use error=TRUE on the block here, as testthat::skip() still fails the vignette build -->
+
+```r
 srv <- vaultr::vault_test_server()
+## Error: vault is not enabled
 ```
 
 

--- a/vignettes_src/packages.Rmd
+++ b/vignettes_src/packages.Rmd
@@ -84,41 +84,22 @@ failure to start a vault server.  This could be for reasons such as:
 * the binary is not in place
 * a port could not be opened
 
-``` {r include = FALSE}
-rm(list = "server_manager", envir = vaultr:::vault_env)
-```
-
 By default this calls `testthat::skip`, which interactively will
 appear to cause an error but if called within a `test_that` block
 in a test will gracefully skip a test
-
-```{r, include = FALSE}
-.vaultr_test_server_bin_path <- Sys.getenv("VAULTR_TEST_SERVER_BIN_PATH")
-```
-
-``` {r }
-Sys.setenv("VAULTR_TEST_SERVER_BIN_PATH" = NA_character_)
-```
-
-<!-- can't use error=TRUE on the block here, as testthat::skip() still fails the vignette build -->
 
 ```r
 srv <- vaultr::vault_test_server()
 ## Error: vault is not enabled
 ```
 
-
 Alternatively, provide your own handler:
-``` {r }
+
+```r
 srv <- vaultr::vault_test_server(if_disabled = message)
-srv
 ```
 
-```{r, include = FALSE}
-Sys.setenv("VAULTR_TEST_SERVER_BIN_PATH" = .vaultr_test_server_bin_path)
-```
-
-With that approach, you might wrap vault-requiring tests with
+In this case, `vaultr::vault_test_server` will return `NULL` and you might wrap vault-requiring tests with:
 
 ```r
 if (!is.null(srv)) {

--- a/vignettes_src/packages.Rmd
+++ b/vignettes_src/packages.Rmd
@@ -91,13 +91,17 @@ rm(list = "server_manager", envir = vaultr:::vault_env)
 By default this calls `testthat::skip`, which interactively will
 appear to cause an error but if called within a `test_that` block
 in a test will gracefully skip a test
+
+```{r, include = FALSE}
+.vaultr_test_server_bin_path <- Sys.getenv("VAULTR_TEST_SERVER_BIN_PATH")
+```
+
 ``` {r }
 Sys.setenv("VAULTR_TEST_SERVER_BIN_PATH" = NA_character_)
 ```
 
-```r
+```{r, error = TRUE}
 srv <- vaultr::vault_test_server()
-## Error: vault is not enabled
 ```
 
 
@@ -105,6 +109,10 @@ Alternatively, provide your own handler:
 ``` {r }
 srv <- vaultr::vault_test_server(if_disabled = message)
 srv
+```
+
+```{r, include = FALSE}
+Sys.setenv("VAULTR_TEST_SERVER_BIN_PATH" = .vaultr_test_server_bin_path)
 ```
 
 With that approach, you might wrap vault-requiring tests with


### PR DESCRIPTION
Try and rebuild vignettes on github. I'm not thrilled about the solution here, but after spending an hour or so on it it's the best I can do as we seem to be at the intersections of issues with `R CMD build` and knitr, and the usual horrors of global state management.